### PR TITLE
Use std::result::Result to avoid shadowing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,16 +124,16 @@ struct S {
 macro_rules! big_array {
     ($name:ident; $($len:tt,)+) => {
         pub trait $name<'de>: Sized {
-            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
                 where S: $crate::reex::Serializer;
-            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
                 where D: $crate::reex::Deserializer<'de>;
         }
         $(
             impl<'de, T> $name<'de> for [T; $len]
                 where T: Default + Copy + $crate::reex::Serialize + $crate::reex::Deserialize<'de>
             {
-                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+                fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
                     where S: $crate::reex::Serializer
                 {
                     use $crate::reex::ser::SerializeTuple;
@@ -144,7 +144,7 @@ macro_rules! big_array {
                     seq.end()
                 }
 
-                fn deserialize<D>(deserializer: D) -> std::result::Result<[T; $len], D::Error>
+                fn deserialize<D>(deserializer: D) -> core::result::Result<[T; $len], D::Error>
                     where D: $crate::reex::Deserializer<'de>
                 {
                     use $crate::reex::PhantomData;
@@ -177,7 +177,7 @@ macro_rules! big_array {
                             write_len!($len)
                         }
 
-                        fn visit_seq<A>(self, mut seq: A) -> std::result::Result<[T; $len], A::Error>
+                        fn visit_seq<A>(self, mut seq: A) -> core::result::Result<[T; $len], A::Error>
                             where A: $crate::reex::SeqAccess<'de>
                         {
                             let mut arr = [T::default(); $len];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ extern crate serde;
 #[doc(hidden)]
 pub mod reex {
     pub use core::fmt;
+    pub use core::result;
     pub use core::marker::PhantomData;
     pub use serde::ser;
     pub use serde::ser::{Serialize, Serializer};
@@ -124,16 +125,16 @@ struct S {
 macro_rules! big_array {
     ($name:ident; $($len:tt,)+) => {
         pub trait $name<'de>: Sized {
-            fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> $crate::reex::result::Result<S::Ok, S::Error>
                 where S: $crate::reex::Serializer;
-            fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> $crate::reex::result::Result<Self, D::Error>
                 where D: $crate::reex::Deserializer<'de>;
         }
         $(
             impl<'de, T> $name<'de> for [T; $len]
                 where T: Default + Copy + $crate::reex::Serialize + $crate::reex::Deserialize<'de>
             {
-                fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+                fn serialize<S>(&self, serializer: S) -> $crate::reex::result::Result<S::Ok, S::Error>
                     where S: $crate::reex::Serializer
                 {
                     use $crate::reex::ser::SerializeTuple;
@@ -144,7 +145,7 @@ macro_rules! big_array {
                     seq.end()
                 }
 
-                fn deserialize<D>(deserializer: D) -> core::result::Result<[T; $len], D::Error>
+                fn deserialize<D>(deserializer: D) -> $crate::reex::result::Result<[T; $len], D::Error>
                     where D: $crate::reex::Deserializer<'de>
                 {
                     use $crate::reex::PhantomData;
@@ -177,7 +178,7 @@ macro_rules! big_array {
                             write_len!($len)
                         }
 
-                        fn visit_seq<A>(self, mut seq: A) -> core::result::Result<[T; $len], A::Error>
+                        fn visit_seq<A>(self, mut seq: A) -> $crate::reex::result::Result<[T; $len], A::Error>
                             where A: $crate::reex::SeqAccess<'de>
                         {
                             let mut arr = [T::default(); $len];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,16 +124,16 @@ struct S {
 macro_rules! big_array {
     ($name:ident; $($len:tt,)+) => {
         pub trait $name<'de>: Sized {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
                 where S: $crate::reex::Serializer;
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
                 where D: $crate::reex::Deserializer<'de>;
         }
         $(
             impl<'de, T> $name<'de> for [T; $len]
                 where T: Default + Copy + $crate::reex::Serialize + $crate::reex::Deserialize<'de>
             {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
                     where S: $crate::reex::Serializer
                 {
                     use $crate::reex::ser::SerializeTuple;
@@ -144,7 +144,7 @@ macro_rules! big_array {
                     seq.end()
                 }
 
-                fn deserialize<D>(deserializer: D) -> Result<[T; $len], D::Error>
+                fn deserialize<D>(deserializer: D) -> std::result::Result<[T; $len], D::Error>
                     where D: $crate::reex::Deserializer<'de>
                 {
                     use $crate::reex::PhantomData;
@@ -177,7 +177,7 @@ macro_rules! big_array {
                             write_len!($len)
                         }
 
-                        fn visit_seq<A>(self, mut seq: A) -> Result<[T; $len], A::Error>
+                        fn visit_seq<A>(self, mut seq: A) -> std::result::Result<[T; $len], A::Error>
                             where A: $crate::reex::SeqAccess<'de>
                         {
                             let mut arr = [T::default(); $len];


### PR DESCRIPTION
Using big_array! in a scope that has redefined the Result type to a custom Result<T> will produce a confusing error:

```
error[E0107]: wrong number of type arguments: expected 1, found 2
  --> src/main.rs:8:1
   |
8  | / big_array! {
9  | |     BigArray;
10 | |     42, 300, 1234, 99999,
11 | | }
   | |_^ unexpected type argument
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

This commit changes the big_array! macro to use std::result::Result instead.