### PR TITLE
Move `serde_derive` to `dev-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", default-features = false }
-serde_derive = "1.0"
 
 [dev-dependencies]
+serde_derive = "1.0"
 serde_json = "1.0"
 


### PR DESCRIPTION
Fixes #13.
If you could cut a new release, that would be amazing too!