### PR TITLE
Allow Serialize XOR Deserialize.

### DIFF
--- a/src/const_generics.rs
+++ b/src/const_generics.rs
@@ -25,22 +25,22 @@ impl<T, const N: usize> Drop for PartiallyInitialized<T, N> {
     }
 }
 
-pub trait BigArray<'de>: Sized {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
-    where
-        S: Serializer;
-    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>;
-}
-
-impl<'de, T, const N: usize> BigArray<'de> for [T; N]
-where
-    T: Serialize + Deserialize<'de>,
-{
+pub trait BigArray<'de, T>: Sized {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
     where
         S: Serializer,
+        T: Serialize;
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>;
+}
+
+impl<'de, T, const N: usize> BigArray<'de, T> for [T; N] {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize,
     {
         let mut seq = serializer.serialize_tuple(self.len())?;
         for elem in &self[..] {
@@ -52,6 +52,7 @@ where
     fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
+        T: Deserialize<'de>,
     {
         struct ArrayVisitor<T> {
             element: PhantomData<T>,

--- a/tests/ser_xor_de.rs
+++ b/tests/ser_xor_de.rs
@@ -1,0 +1,41 @@
+#![no_std]
+#![allow(deprecated)]
+
+use serde_big_array::big_array;
+use serde_derive::{Deserialize, Serialize};
+
+big_array! { BigArray; }
+
+#[derive(Serialize)]
+struct S {
+    #[serde(with = "BigArray")]
+    arr: [SerOnly; 64],
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct SerOnly(u8);
+
+#[derive(Deserialize)]
+struct D {
+    #[serde(with = "BigArray")]
+    arr: [DeOnly; 64],
+}
+
+#[derive(Clone, Copy, Deserialize)]
+struct DeOnly(u8);
+
+impl PartialEq<DeOnly> for SerOnly {
+    fn eq(&self, other: &DeOnly) -> bool {
+        self.0 == other.0
+    }
+}
+
+#[test]
+fn test() {
+    let s = S {
+        arr: [SerOnly(1); 64],
+    };
+    let j = serde_json::to_string(&s).unwrap();
+    let s_back = serde_json::from_str::<D>(&j).unwrap();
+    assert!(&s.arr[..] == &s_back.arr[..]);
+}


### PR DESCRIPTION
As-is, [this impl](https://docs.rs/serde-big-array/latest/serde_big_array/trait.BigArray.html#impl-BigArray%3C%27de%3E-for-%5BT%3B%20N%5D) only allows `impl BigArray` if `T: Serialize + Deserialize`.

This PR allows use cases that only need `Serialize` *or* `Deserialize` but not both. This is especially useful when one of the two is more difficult to implement on the item type.

Note: Added a new test on `Serialize`-only data and `Deserialize`-only data.

Warning: This may be a breaking change. However, all the old tests passed unmodified.