### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/const_generics.rs
+++ b/src/const_generics.rs
@@ -71,7 +71,7 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                unsafe {
+                
                     let mut arr: PartiallyInitialized<T, N> =
                         PartiallyInitialized(Some(MaybeUninit::uninit()), 0);
                     {
@@ -81,13 +81,13 @@ where
                             let val = seq
                                 .next_element()?
                                 .ok_or_else(|| Error::invalid_length(i, &self))?;
-                            core::ptr::write(p, val);
+                            unsafe { core::ptr::write(p, val) };
                             arr.1 += 1;
                         }
                     }
-                    let initialized = arr.0.take().unwrap().assume_init();
+                    let initialized = unsafe { arr.0.take().unwrap().assume_init() };
                     Ok(initialized)
-                }
+                
             }
         }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html